### PR TITLE
Add ESP32 Arduino sketch for polyphonic synthesizer

### DIFF
--- a/conexiones_esp32.md
+++ b/conexiones_esp32.md
@@ -2,6 +2,8 @@
 
 Este documento describe cómo cablear los botones de notas, los controles adicionales y la salida de audio de la placa ESP32 para el boceto `esp32_synth.ino`.
 
+![Esquema de conexiones propuesto](diagramas/esquema_conexiones.svg)
+
 ## Alimentación y referencias
 - **VIN / 5V**: Alimenta la placa ESP32 según el módulo utilizado (puede ser por USB o una fuente regulada externa).
 - **3V3**: Alimenta los componentes que requieran 3,3 V (por ejemplo, el lado de referencia de los pulsadores si se usan en configuración pull-up externa).

--- a/conexiones_esp32.md
+++ b/conexiones_esp32.md
@@ -1,0 +1,40 @@
+# Guía de cableado del sintetizador ESP32
+
+Este documento describe cómo cablear los botones de notas, los controles adicionales y la salida de audio de la placa ESP32 para el boceto `esp32_synth.ino`.
+
+## Alimentación y referencias
+- **VIN / 5V**: Alimenta la placa ESP32 según el módulo utilizado (puede ser por USB o una fuente regulada externa).
+- **3V3**: Alimenta los componentes que requieran 3,3 V (por ejemplo, el lado de referencia de los pulsadores si se usan en configuración pull-up externa).
+- **GND**: Conecta todas las tierras de botones, altavoz, amplificador y fuente a este punto común.
+
+## Botones de notas (escala de do mayor)
+Los ocho pulsadores de nota funcionan en modo **activo a nivel bajo** y en el código se configuran con `INPUT_PULLUP`, por lo que cada botón debe conectar su pin a **GND** cuando se pulsa. Conecta el otro terminal de cada botón al pin GPIO indicado:
+
+| Nota | Pin GPIO ESP32 |
+|------|----------------|
+| Do4  | GPIO 32        |
+| Re4  | GPIO 33        |
+| Mi4  | GPIO 27        |
+| Fa4  | GPIO 14        |
+| Sol4 | GPIO 12        |
+| La4  | GPIO 13        |
+| Si4  | GPIO 15        |
+| Do5  | GPIO 4         |
+
+## Botones de control
+Los botones de instrumento y ritmo también se leen como **activo a nivel bajo**. Conecta un terminal del botón a GND y el otro al GPIO correspondiente.
+
+| Función                      | Pin GPIO ESP32 |
+|------------------------------|----------------|
+| Cambio de instrumento        | GPIO 18        |
+| Activación/cambio de ritmos  | GPIO 19        |
+
+## Salida de audio
+- El boceto utiliza el **DAC interno del ESP32 en GPIO 25**. Conecta este pin a la entrada de un **amplificador de audio** o a un **altavoz autoamplificado**.
+- Añade un condensador de acoplamiento (p. ej. 10 µF en serie) si el amplificador requiere entrada AC y/o para proteger frente a componentes DC.
+- Si se conecta directamente a un pequeño altavoz pasivo, utiliza un amplificador intermedio o un módulo clase D para evitar sobrecargar el pin del ESP32.
+
+## Recomendaciones adicionales
+- Mantén los cables de señal cortos y, si es posible, utiliza resistencias en serie de 100-220 Ω entre el pin DAC y la entrada del amplificador para reducir el ruido y proteger el microcontrolador.
+- Para evitar rebotes mecánicos excesivos, se recomienda emplear pulsadores de buena calidad o añadir condensadores de 0,1 µF en paralelo con cada botón.
+- Comprueba que todos los componentes compartan la misma referencia de tierra.

--- a/diagramas/esquema_conexiones.svg
+++ b/diagramas/esquema_conexiones.svg
@@ -1,0 +1,94 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="900" viewBox="0 0 1400 900">
+  <style>
+    .title { font: bold 32px 'Segoe UI', sans-serif; fill: #222; }
+    .label { font: 20px 'Segoe UI', sans-serif; fill: #222; }
+    .label-small { font: 18px 'Segoe UI', sans-serif; fill: #222; }
+    .label-white { font: 20px 'Segoe UI', sans-serif; fill: #fff; }
+    .box-esp32 { fill: #3a6ed0; stroke: #1d3f8a; stroke-width: 4; }
+    .box-button { fill: #8dd0ff; stroke: #1d3f8a; stroke-width: 3; }
+    .box-audio { fill: #f8b35b; stroke: #c97a1a; stroke-width: 3; }
+    .connection { stroke: #222; stroke-width: 4; fill: none; }
+    .connection-thin { stroke: #222; stroke-width: 3; fill: none; }
+    .gnd-line { stroke: #444; stroke-width: 4; stroke-dasharray: 12 12; fill: none; }
+  </style>
+  <text x="220" y="70" class="title">Esquema simplificado de conexiones del sintetizador ESP32</text>
+  <!-- ESP32 -->
+  <rect x="540" y="250" width="320" height="360" rx="18" class="box-esp32" />
+  <text x="700" y="300" text-anchor="middle" class="label-white">ESP32</text>
+  <text x="420" y="335" class="label-white">GPIO 32</text>
+  <text x="420" y="370" class="label-white">GPIO 33</text>
+  <text x="420" y="405" class="label-white">GPIO 27</text>
+  <text x="420" y="440" class="label-white">GPIO 14</text>
+  <text x="420" y="475" class="label-white">GPIO 12</text>
+  <text x="420" y="510" class="label-white">GPIO 13</text>
+  <text x="420" y="545" class="label-white">GPIO 15</text>
+  <text x="420" y="580" class="label-white">GPIO 4</text>
+  <text x="420" y="615" class="label-white">GND común</text>
+  <text x="880" y="615" class="label-white">+3.3 V</text>
+  <!-- Audio output -->
+  <rect x="560" y="80" width="280" height="120" rx="18" class="box-audio" />
+  <text x="700" y="140" text-anchor="middle" class="label">Amplificador + Altavoz</text>
+  <text x="700" y="170" text-anchor="middle" class="label-small">Salida DAC GPIO 25 (opcional GPIO 26)</text>
+  <line x1="700" y1="200" x2="700" y2="250" class="connection" />
+  <!-- Note buttons -->
+  <g>
+    <rect x="80" y="140" width="250" height="70" rx="18" class="box-button" />
+    <text x="205" y="185" text-anchor="middle" class="label">Botón nota Do4</text>
+    <line x1="330" y1="175" x2="540" y2="330" class="connection-thin" />
+  </g>
+  <g>
+    <rect x="80" y="230" width="250" height="70" rx="18" class="box-button" />
+    <text x="205" y="275" text-anchor="middle" class="label">Botón nota Re4</text>
+    <line x1="330" y1="265" x2="540" y2="365" class="connection-thin" />
+  </g>
+  <g>
+    <rect x="80" y="320" width="250" height="70" rx="18" class="box-button" />
+    <text x="205" y="365" text-anchor="middle" class="label">Botón nota Mi4</text>
+    <line x1="330" y1="355" x2="540" y2="400" class="connection-thin" />
+  </g>
+  <g>
+    <rect x="80" y="410" width="250" height="70" rx="18" class="box-button" />
+    <text x="205" y="455" text-anchor="middle" class="label">Botón nota Fa4</text>
+    <line x1="330" y1="445" x2="540" y2="435" class="connection-thin" />
+  </g>
+  <g>
+    <rect x="80" y="500" width="250" height="70" rx="18" class="box-button" />
+    <text x="205" y="545" text-anchor="middle" class="label">Botón nota Sol4</text>
+    <line x1="330" y1="535" x2="540" y2="470" class="connection-thin" />
+  </g>
+  <g>
+    <rect x="80" y="590" width="250" height="70" rx="18" class="box-button" />
+    <text x="205" y="635" text-anchor="middle" class="label">Botón nota La4</text>
+    <line x1="330" y1="625" x2="540" y2="505" class="connection-thin" />
+  </g>
+  <g>
+    <rect x="80" y="680" width="250" height="70" rx="18" class="box-button" />
+    <text x="205" y="725" text-anchor="middle" class="label">Botón nota Si4</text>
+    <line x1="330" y1="715" x2="540" y2="540" class="connection-thin" />
+  </g>
+  <g>
+    <rect x="80" y="770" width="250" height="70" rx="18" class="box-button" />
+    <text x="205" y="815" text-anchor="middle" class="label">Botón nota Do5</text>
+    <line x1="330" y1="805" x2="540" y2="575" class="connection-thin" />
+  </g>
+  <!-- Control buttons -->
+  <g>
+    <rect x="1020" y="320" width="260" height="120" rx="18" class="box-button" />
+    <text x="1150" y="370" text-anchor="middle" class="label">Botón selector</text>
+    <text x="1150" y="405" text-anchor="middle" class="label">de instrumentos</text>
+    <line x1="1020" y1="380" x2="860" y2="380" class="connection-thin" />
+    <text x="1170" y="455" class="label-small">GPIO 18</text>
+  </g>
+  <g>
+    <rect x="1020" y="480" width="260" height="120" rx="18" class="box-button" />
+    <text x="1150" y="530" text-anchor="middle" class="label">Botón selector</text>
+    <text x="1150" y="565" text-anchor="middle" class="label">de ritmos</text>
+    <line x1="1020" y1="540" x2="860" y2="430" class="connection-thin" />
+    <text x="1170" y="605" class="label-small">GPIO 19</text>
+  </g>
+  <!-- Shared ground and power rails -->
+  <path d="M540 620 H360 V860 H1190 V720" class="gnd-line" />
+  <text x="380" y="845" class="label">Barra de GND común para todos los pulsadores y módulos</text>
+  <path d="M860 620 H1240 V680" class="connection" stroke="#c43" stroke-width="4" fill="none" />
+  <text x="1245" y="685" class="label">Distribución +3.3 V a botones y módulos auxiliares</text>
+</svg>

--- a/esp32_synth.ino
+++ b/esp32_synth.ino
@@ -1,0 +1,333 @@
+#include <Arduino.h>
+#include <esp_system.h>
+#include <math.h>
+
+/**
+ * Simple polyphonic synthesizer for ESP32 using the Arduino framework.
+ *
+ * Features:
+ *  - Eight note buttons laid out as a C major scale (C4 to C5).
+ *  - Supports holding multiple keys for polyphonic playback.
+ *  - Instrument toggle button that cycles through piano, guitar, violin and
+ *    a fantasy synthesizer voice.
+ *  - Rhythm toggle button that cycles through a collection of preset groove
+ *    patterns which play alongside the notes.
+ *  - Audio is generated on the ESP32 DAC (GPIO 25) using a timer interrupt.
+ */
+
+// ---------------------------------------------------------------------------
+// Audio configuration
+// ---------------------------------------------------------------------------
+
+constexpr uint32_t SAMPLE_RATE = 22050;          // Audio sample rate in Hz
+constexpr uint8_t DAC_PIN = 25;                  // Built-in DAC channel 1
+constexpr uint8_t TIMER_INDEX = 0;               // Hardware timer to use
+constexpr uint16_t TIMER_DIVIDER = 80;           // 1 µs per timer tick
+constexpr uint32_t TIMER_INTERVAL_US = 1000000UL / SAMPLE_RATE;
+constexpr float TWO_PI = 2.0f * static_cast<float>(M_PI);
+
+// ---------------------------------------------------------------------------
+// Musical configuration
+// ---------------------------------------------------------------------------
+
+constexpr size_t NUM_NOTES = 8; // C major scale
+
+// GPIO pins connected to note buttons (active LOW, uses INPUT_PULLUP).
+constexpr uint8_t NOTE_PINS[NUM_NOTES] = {32, 33, 27, 14, 12, 13, 15, 4};
+
+// Frequencies (Hz) for C major scale starting at middle C (C4).
+constexpr float NOTE_FREQUENCIES[NUM_NOTES] = {
+    261.63f, // C4
+    293.66f, // D4
+    329.63f, // E4
+    349.23f, // F4
+    392.00f, // G4
+    440.00f, // A4
+    493.88f, // B4
+    523.25f  // C5
+};
+
+// Instrument and rhythm control buttons (active LOW, uses INPUT_PULLUP).
+constexpr uint8_t INSTRUMENT_BUTTON_PIN = 18;
+constexpr uint8_t RHYTHM_BUTTON_PIN = 19;
+
+// Debounce time for all buttons in milliseconds.
+constexpr uint16_t DEBOUNCE_MS = 25;
+
+// ---------------------------------------------------------------------------
+// Instrument definitions
+// ---------------------------------------------------------------------------
+
+enum Instrument : uint8_t {
+  INSTRUMENT_PIANO = 0,
+  INSTRUMENT_GUITAR,
+  INSTRUMENT_VIOLIN,
+  INSTRUMENT_FANTASY,
+  NUM_INSTRUMENTS
+};
+
+// ---------------------------------------------------------------------------
+// Rhythm pattern definitions
+// ---------------------------------------------------------------------------
+
+struct RhythmPattern {
+  const float *steps;    // Step intensities (0..1)
+  uint8_t length;        // Number of steps in the pattern
+  float bpm;             // Tempo for the pattern
+};
+
+constexpr uint8_t MAX_RHYTHM_STEPS = 16;
+
+// Intensity arrays for rhythm patterns (stored in flash).
+constexpr float RHYTHM_PATTERN_1[MAX_RHYTHM_STEPS] = {
+    1.0f, 0.0f, 0.5f, 0.0f,
+    0.8f, 0.0f, 0.4f, 0.0f,
+    1.0f, 0.0f, 0.5f, 0.0f,
+    0.6f, 0.0f, 0.3f, 0.0f};
+
+constexpr float RHYTHM_PATTERN_2[MAX_RHYTHM_STEPS] = {
+    1.0f, 0.0f, 0.7f, 0.0f,
+    0.0f, 0.5f, 0.0f, 0.4f,
+    0.9f, 0.0f, 0.6f, 0.0f,
+    0.0f, 0.5f, 0.0f, 0.3f};
+
+constexpr float RHYTHM_PATTERN_3[MAX_RHYTHM_STEPS] = {
+    1.0f, 0.0f, 0.6f, 0.0f,
+    0.7f, 0.0f, 0.5f, 0.0f,
+    0.9f, 0.0f, 0.4f, 0.0f,
+    0.7f, 0.0f, 0.5f, 0.0f};
+
+constexpr RhythmPattern RHYTHMS[] = {
+    {RHYTHM_PATTERN_1, 16, 92.0f},
+    {RHYTHM_PATTERN_2, 16, 108.0f},
+    {RHYTHM_PATTERN_3, 16, 124.0f},
+};
+
+constexpr int NUM_RHYTHMS = sizeof(RHYTHMS) / sizeof(RHYTHMS[0]);
+
+// ---------------------------------------------------------------------------
+// Button handling helper structure
+// ---------------------------------------------------------------------------
+
+struct ButtonState {
+  uint8_t pin;
+  bool lastReading;
+  bool stableState;
+  uint32_t lastDebounce;
+};
+
+ButtonState noteButtons[NUM_NOTES];
+ButtonState instrumentButton{INSTRUMENT_BUTTON_PIN, false, false, 0};
+ButtonState rhythmButton{RHYTHM_BUTTON_PIN, false, false, 0};
+
+// ---------------------------------------------------------------------------
+// Shared state between loop() and timer interrupt
+// ---------------------------------------------------------------------------
+
+portMUX_TYPE timerMux = portMUX_INITIALIZER_UNLOCKED;
+
+volatile bool noteActive[NUM_NOTES] = {false};
+volatile float noteEnvelope[NUM_NOTES] = {0.0f};
+float notePhase[NUM_NOTES] = {0.0f};
+
+volatile Instrument currentInstrument = INSTRUMENT_PIANO;
+
+volatile bool rhythmEnabled = false;
+volatile int activeRhythm = -1; // -1 = off
+volatile uint8_t rhythmStep = 0;
+volatile float rhythmEnvelope = 0.0f;
+volatile uint32_t nextRhythmStepSample = 0;
+volatile uint32_t rhythmStepIntervalSamples = 1;
+volatile uint32_t sampleCounter = 0;
+volatile float rhythmPhase = 0.0f;
+
+hw_timer_t *audioTimer = nullptr;
+
+// ---------------------------------------------------------------------------
+// Utility functions
+// ---------------------------------------------------------------------------
+
+bool updateButton(ButtonState &button, uint32_t nowMillis) {
+  const bool reading = (digitalRead(button.pin) == LOW);
+
+  if (reading != button.lastReading) {
+    button.lastDebounce = nowMillis;
+  }
+
+  if ((nowMillis - button.lastDebounce) > DEBOUNCE_MS) {
+    if (reading != button.stableState) {
+      button.stableState = reading;
+      button.lastReading = reading;
+      return true; // state changed after debounce
+    }
+  }
+
+  button.lastReading = reading;
+  return false;
+}
+
+float applyInstrumentWave(Instrument instrument, float phase) {
+  const float angle = TWO_PI * phase;
+
+  switch (instrument) {
+    case INSTRUMENT_PIANO:
+      return sinf(angle);
+    case INSTRUMENT_GUITAR:
+      return 0.7f * sinf(angle) + 0.3f * sinf(2.0f * angle);
+    case INSTRUMENT_VIOLIN:
+      return 0.6f * sinf(angle) + 0.25f * sinf(3.0f * angle);
+    case INSTRUMENT_FANTASY:
+      return 0.4f * sinf(angle) + 0.4f * sinf(2.0f * angle + sinf(5.0f * angle)) +
+             0.2f * sinf(0.5f * angle);
+    default:
+      return sinf(angle);
+  }
+}
+
+void updateRhythmSelectionLocked(int rhythmIndex) {
+  if (rhythmIndex < 0 || rhythmIndex >= NUM_RHYTHMS) {
+    rhythmEnabled = false;
+    activeRhythm = -1;
+    rhythmStep = 0;
+    rhythmEnvelope = 0.0f;
+    rhythmPhase = 0.0f;
+    nextRhythmStepSample = sampleCounter;
+    rhythmStepIntervalSamples = 1;
+    return;
+  }
+
+  const RhythmPattern &pattern = RHYTHMS[rhythmIndex];
+  const float stepsPerBeat = 4.0f; // 16th notes
+  const float secondsPerStep = 60.0f / (pattern.bpm * stepsPerBeat);
+
+  rhythmEnabled = true;
+  activeRhythm = rhythmIndex;
+  rhythmStep = 0;
+  rhythmEnvelope = 0.0f;
+  rhythmPhase = 0.0f;
+  sampleCounter = 0;
+  rhythmStepIntervalSamples = static_cast<uint32_t>(secondsPerStep * SAMPLE_RATE);
+  if (rhythmStepIntervalSamples == 0) {
+    rhythmStepIntervalSamples = 1;
+  }
+  nextRhythmStepSample = 0;
+}
+
+// ---------------------------------------------------------------------------
+// Audio generation ISR
+// ---------------------------------------------------------------------------
+
+void IRAM_ATTR onAudioTimer() {
+  portENTER_CRITICAL_ISR(&timerMux);
+
+  float mix = 0.0f;
+
+  for (size_t i = 0; i < NUM_NOTES; ++i) {
+    if (noteActive[i]) {
+      // Attack towards full volume when pressed.
+      noteEnvelope[i] += (1.0f - noteEnvelope[i]) * 0.01f;
+    } else {
+      // Release back to zero when not pressed.
+      noteEnvelope[i] *= 0.995f;
+    }
+
+    if (noteEnvelope[i] > 0.0005f) {
+      notePhase[i] += NOTE_FREQUENCIES[i] / static_cast<float>(SAMPLE_RATE);
+      if (notePhase[i] >= 1.0f) {
+        notePhase[i] -= 1.0f;
+      }
+
+      mix += noteEnvelope[i] * applyInstrumentWave(currentInstrument, notePhase[i]);
+    }
+  }
+
+  if (rhythmEnabled && activeRhythm >= 0) {
+    if (sampleCounter >= nextRhythmStepSample) {
+      const RhythmPattern &pattern = RHYTHMS[activeRhythm];
+      rhythmEnvelope = pattern.steps[rhythmStep % pattern.length];
+      nextRhythmStepSample += rhythmStepIntervalSamples;
+      rhythmStep = (rhythmStep + 1) % pattern.length;
+    }
+
+    // Simple percussive envelope decay and noise-based drum hit.
+    rhythmEnvelope *= 0.997f;
+    rhythmPhase += 120.0f / static_cast<float>(SAMPLE_RATE);
+    if (rhythmPhase >= 1.0f) {
+      rhythmPhase -= 1.0f;
+    }
+
+    const float drum = (sinf(TWO_PI * rhythmPhase) + ((float)esp_random() / UINT32_MAX) - 0.5f) * 0.5f;
+    mix += rhythmEnvelope * drum;
+  }
+
+  // Simple master limiter to keep the mix within [-1, 1].
+  mix = constrain(mix * 0.6f, -1.0f, 1.0f);
+
+  const uint8_t outputValue = static_cast<uint8_t>((mix * 127.0f) + 128.0f);
+  dacWrite(DAC_PIN, outputValue);
+
+  ++sampleCounter;
+
+  portEXIT_CRITICAL_ISR(&timerMux);
+}
+
+// ---------------------------------------------------------------------------
+// Arduino setup and loop
+// ---------------------------------------------------------------------------
+
+void setupButtons() {
+  for (size_t i = 0; i < NUM_NOTES; ++i) {
+    pinMode(NOTE_PINS[i], INPUT_PULLUP);
+    const bool pressed = (digitalRead(NOTE_PINS[i]) == LOW);
+    noteButtons[i] = {NOTE_PINS[i], pressed, pressed, 0};
+    noteActive[i] = pressed;
+  }
+
+  pinMode(INSTRUMENT_BUTTON_PIN, INPUT_PULLUP);
+  const bool instrumentPressed = (digitalRead(INSTRUMENT_BUTTON_PIN) == LOW);
+  instrumentButton = {INSTRUMENT_BUTTON_PIN, instrumentPressed, instrumentPressed, 0};
+
+  pinMode(RHYTHM_BUTTON_PIN, INPUT_PULLUP);
+  const bool rhythmPressed = (digitalRead(RHYTHM_BUTTON_PIN) == LOW);
+  rhythmButton = {RHYTHM_BUTTON_PIN, rhythmPressed, rhythmPressed, 0};
+}
+
+void setupTimer() {
+  audioTimer = timerBegin(TIMER_INDEX, TIMER_DIVIDER, true);
+  timerAttachInterrupt(audioTimer, &onAudioTimer, true);
+  timerAlarmWrite(audioTimer, TIMER_INTERVAL_US, true);
+  timerAlarmEnable(audioTimer);
+}
+
+void setup() {
+  setupButtons();
+  setupTimer();
+}
+
+void loop() {
+  const uint32_t now = millis();
+
+  for (size_t i = 0; i < NUM_NOTES; ++i) {
+    if (updateButton(noteButtons[i], now)) {
+      portENTER_CRITICAL(&timerMux);
+      noteActive[i] = noteButtons[i].stableState;
+      portEXIT_CRITICAL(&timerMux);
+    }
+  }
+
+  if (updateButton(instrumentButton, now) && instrumentButton.stableState) {
+    portENTER_CRITICAL(&timerMux);
+    currentInstrument = static_cast<Instrument>((currentInstrument + 1) % NUM_INSTRUMENTS);
+    portEXIT_CRITICAL(&timerMux);
+  }
+
+  if (updateButton(rhythmButton, now) && rhythmButton.stableState) {
+    static int rhythmSelection = -1;
+    rhythmSelection = (rhythmSelection + 2) % (NUM_RHYTHMS + 1) - 1; // Cycle -1 -> 0 -> 1 -> ...
+
+    portENTER_CRITICAL(&timerMux);
+    updateRhythmSelectionLocked(rhythmSelection);
+    portEXIT_CRITICAL(&timerMux);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add an ESP32-focused Arduino sketch that turns note buttons into a polyphonic synthesizer spanning a C major scale
- support switching among piano, guitar, violin, and fantasy instrument voices while layering preset rhythm patterns

## Testing
- not run (hardware-dependent)


------
https://chatgpt.com/codex/tasks/task_e_68d84179c4f08332ad21b17d308642fd